### PR TITLE
Fix PHP syntax error in bell.svg SVG file (keeping it a valid XML file)

### DIFF
--- a/wp-web-push/lib/bell.svg
+++ b/wp-web-push/lib/bell.svg
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?php
+echo '<?xml version="1.0" encoding="UTF-8" standalone="no"?'.'>';
+?>
 <svg width="112px" height="112px" viewBox="0 0 112 112" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 3.6 (26304) - http://www.bohemiancoding.com/sketch -->
     <title>bell</title>


### PR DESCRIPTION
Fixes #266.

This fixes the syntax error happening on systems with PHP short tags enabled. The SVG file is still valid XML (because the string is echoed as `?'.'>'` and not `?>'`).
