### PR TITLE
Use curl_multi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,10 @@ build: $(COMPOSER)
 	mv build/$(PLUGIN_NAME).zip $(PLUGIN_NAME).zip
 
 test: $(PHPUNIT) build
+	-pkill node
+	node tests/server.js &
 	$(PHPUNIT)
+	-pkill node -n
 
 version-changelog:
 	./version-changelog.js $(PLUGIN_NAME)

--- a/tests/server.js
+++ b/tests/server.js
@@ -3,6 +3,10 @@ var http = require('http');
 var num = 0;
 
 var server = http.createServer(function(req, res) {
+  var parts = req.url.split('/');
+  var code = parts[1];
+  var isGCM = parts[2] === 'gcm';
+
   if (req.method === 'GET') {
     res.writeHead(202);
     res.end(num.toString());
@@ -14,16 +18,56 @@ var server = http.createServer(function(req, res) {
     return;
   }
 
-  if (!req.headers['ttl']) {
-    res.writeHead(500);
-    return;
-  }
-
   num++;
 
-  var code = req.url.substr(1);
-  res.writeHead(code);
-  res.end('ok');
+  if (isGCM) {
+    if (req.headers['authorization'] !== 'key=aKey') {
+    console.log(req.headers['authorization'])
+      res.writeHead(500);
+      return;
+    }
+
+    if (req.headers['content-type'] !== 'application/json') {
+      res.writeHead(500);
+      return;
+    }
+
+    if (req.headers['content-length'] !== '33') {
+      res.writeHead(500);
+      return;
+    }
+
+    var body = '';
+
+    req.on('data', function(chunk) {
+      body += chunk;
+    });
+
+    req.on('end', function() {
+      var data = JSON.parse(body);
+
+      if (data.registration_ids.length !== 1) {
+        res.writeHead(500);
+        return;
+      }
+
+      if (data.registration_ids[0] !== 'endpoint') {
+        res.writeHead(500);
+        return;
+      }
+
+      res.writeHead(code);
+      res.end('ok');
+    });
+  } else {
+    if (!req.headers['ttl']) {
+      res.writeHead(500);
+      return;
+    }
+
+    res.writeHead(code);
+    res.end('ok');
+  }
 });
 
 server.listen(55555);

--- a/tests/server.js
+++ b/tests/server.js
@@ -1,0 +1,30 @@
+var http = require('http');
+
+var num = 0;
+
+var server = http.createServer(function(req, res) {
+  if (req.method === 'GET') {
+    res.writeHead(202);
+    res.end(num.toString());
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res.writeHead(500);
+    return;
+  }
+
+  if (!req.headers['ttl']) {
+    res.writeHead(500);
+    return;
+  }
+
+  num++;
+
+  var code = req.url.substr(1);
+  res.writeHead(code);
+  res.end('ok');
+});
+
+server.listen(55555);
+

--- a/tests/test-send-notification.php
+++ b/tests/test-send-notification.php
@@ -3,8 +3,8 @@
 require_once dirname(dirname(__FILE__)) . '/build/web-push.php';
 
 class SendNotificationTest extends WP_UnitTestCase {
-  function test_send_webpush_notification_success() {
-    $webPush = new WebPush();
+  function send_webpush_notification_success($forceWP) {
+    $webPush = new WebPush($forceWP);
     $self = $this;
     $webPush->addRecipient('http://localhost:55555/201', false, 'aKey', function($success) use ($self) {
       $self->assertTrue($success);
@@ -12,8 +12,13 @@ class SendNotificationTest extends WP_UnitTestCase {
     $webPush->sendNotifications();
   }
 
-  function test_send_webpush_notification_success_no_key() {
-    $webPush = new WebPush();
+  function test_send_webpush_notification_success() {
+    $this->send_webpush_notification_success(false);
+    $this->send_webpush_notification_success(true);
+  }
+
+  function send_webpush_notification_success_no_key($forceWP) {
+    $webPush = new WebPush($forceWP);
     $self = $this;
     $webPush->addRecipient('http://localhost:55555/201', false, '', function($success) use ($self) {
       $self->assertTrue($success);
@@ -21,8 +26,13 @@ class SendNotificationTest extends WP_UnitTestCase {
     $webPush->sendNotifications();
   }
 
-  function test_send_webpush_notification_failure() {
-    $webPush = new WebPush();
+  function test_send_webpush_notification_success_no_key() {
+    $this->send_webpush_notification_success_no_key(false);
+    $this->send_webpush_notification_success_no_key(true);
+  }
+
+  function send_webpush_notification_failure($forceWP) {
+    $webPush = new WebPush($forceWP);
     $self = $this;
     $webPush->addRecipient('http://localhost:55555/400', false, 'aKey', function($success) use ($self) {
       $self->assertFalse($success);
@@ -30,8 +40,13 @@ class SendNotificationTest extends WP_UnitTestCase {
     $webPush->sendNotifications();
   }
 
-  function test_send_gcm_notification_success() {
-    $webPush = new WebPush();
+  function test_send_webpush_notification_failure() {
+    $this->send_webpush_notification_failure(false);
+    $this->send_webpush_notification_failure(true);
+  }
+
+  function send_gcm_notification_success($forceWP) {
+    $webPush = new WebPush($forceWP);
     $self = $this;
     $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey', function($success) use ($self) {
       $self->assertTrue($success);
@@ -42,8 +57,13 @@ class SendNotificationTest extends WP_UnitTestCase {
     $webPush->sendNotifications();
   }
 
-  function test_send_gcm_notification_failure() {
-    $webPush = new WebPush();
+  function test_send_gcm_notification_success() {
+    $this->send_gcm_notification_success(false);
+    $this->send_gcm_notification_success(true);
+  }
+
+  function send_gcm_notification_failure($forceWP) {
+    $webPush = new WebPush($forceWP);
     $self = $this;
     $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey', function($success) use ($self) {
       $self->assertFalse($success);
@@ -52,6 +72,11 @@ class SendNotificationTest extends WP_UnitTestCase {
     $webPush->requests[0]['url'] = 'http://localhost:55555/400/gcm';
 
     $webPush->sendNotifications();
+  }
+
+  function test_send_gcm_notification_failure() {
+    $this->send_gcm_notification_failure(false);
+    $this->send_gcm_notification_failure(true);
   }
 
   /*function test_send_notification_error() {

--- a/tests/test-send-notification.php
+++ b/tests/test-send-notification.php
@@ -8,7 +8,7 @@ class SendNotificationTest extends WP_UnitTestCase {
 
     $webPush = new WebPush($forceWP);
     $self = $this;
-    $webPush->addRecipient('http://localhost:55555/201', false, 'aKey', function($success) use ($self) {
+    $webPush->addRecipient('http://localhost:55555/201', 'aKey', function($success) use ($self) {
       $self->assertTrue($success);
     });
     $webPush->sendNotifications();
@@ -26,7 +26,7 @@ class SendNotificationTest extends WP_UnitTestCase {
 
     $webPush = new WebPush($forceWP);
     $self = $this;
-    $webPush->addRecipient('http://localhost:55555/201', false, '', function($success) use ($self) {
+    $webPush->addRecipient('http://localhost:55555/201', '', function($success) use ($self) {
       $self->assertTrue($success);
     });
     $webPush->sendNotifications();
@@ -44,7 +44,7 @@ class SendNotificationTest extends WP_UnitTestCase {
 
     $webPush = new WebPush($forceWP);
     $self = $this;
-    $webPush->addRecipient('http://localhost:55555/400', false, 'aKey', function($success) use ($self) {
+    $webPush->addRecipient('http://localhost:55555/400', 'aKey', function($success) use ($self) {
       $self->assertFalse($success);
     });
     $webPush->sendNotifications();
@@ -62,7 +62,7 @@ class SendNotificationTest extends WP_UnitTestCase {
 
     $webPush = new WebPush($forceWP);
     $self = $this;
-    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey', function($success) use ($self) {
+    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', 'aKey', function($success) use ($self) {
       $self->assertTrue($success);
     });
 
@@ -83,7 +83,7 @@ class SendNotificationTest extends WP_UnitTestCase {
 
     $webPush = new WebPush($forceWP);
     $self = $this;
-    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey', function($success) use ($self) {
+    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', 'aKey', function($success) use ($self) {
       $self->assertFalse($success);
     });
 
@@ -108,7 +108,7 @@ class SendNotificationTest extends WP_UnitTestCase {
 
     $webPush = new WebPush(true);
     $self = $this;
-    $webPush->addRecipient('endpoint', false, 'aKey', function($success) use ($self) {
+    $webPush->addRecipient('endpoint', 'aKey', function($success) use ($self) {
       $self->assertTrue($success);
     });
     $webPush->sendNotifications();
@@ -121,13 +121,13 @@ class SendNotificationTest extends WP_UnitTestCase {
 
     $webPush = new WebPush($forceWP);
     $self = $this;
-    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey', function($success) use ($self) {
+    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', 'aKey', function($success) use ($self) {
       $self->assertTrue($success);
     });
-    $webPush->addRecipient('http://localhost:55555/400', false, 'aKey', function($success) use ($self) {
+    $webPush->addRecipient('http://localhost:55555/400', 'aKey', function($success) use ($self) {
       $self->assertFalse($success);
     });
-    $webPush->addRecipient('http://localhost:55555/201', false, 'aKey', function($success) use ($self) {
+    $webPush->addRecipient('http://localhost:55555/201', 'aKey', function($success) use ($self) {
       $self->assertTrue($success);
     });
 

--- a/tests/test-send-notification.php
+++ b/tests/test-send-notification.php
@@ -25,7 +25,9 @@ class SendNotificationTest extends WP_UnitTestCase {
     }, 10, 2);
 
     $webPush = new WebPush();
-    $webPush->addRecipient('endpoint', false, 'aKey');
+    $webPush->addRecipient('endpoint', false, 'aKey', function($success) {
+      $this->assertTrue($success);
+    });
     $webPush->sendNotifications();
   }
 
@@ -43,7 +45,9 @@ class SendNotificationTest extends WP_UnitTestCase {
     });
 
     $webPush = new WebPush();
-    $webPush->addRecipient('endpoint', false, '');
+    $webPush->addRecipient('endpoint', false, '', function($success) {
+      $this->assertTrue($success);
+    });
     $webPush->sendNotifications();
   }
 
@@ -61,7 +65,9 @@ class SendNotificationTest extends WP_UnitTestCase {
     });
 
     $webPush = new WebPush();
-    $webPush->addRecipient('endpoint', false, 'aKey');
+    $webPush->addRecipient('endpoint', false, 'aKey', function($success) {
+      $this->assertFalse($success);
+    });
     $webPush->sendNotifications();
   }
 
@@ -88,7 +94,9 @@ class SendNotificationTest extends WP_UnitTestCase {
     }, 10, 2);
 
     $webPush = new WebPush();
-    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey');
+    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey', function($success) {
+      $this->assertTrue($success);
+    });
     $webPush->sendNotifications();
   }
 
@@ -106,7 +114,9 @@ class SendNotificationTest extends WP_UnitTestCase {
     });
 
     $webPush = new WebPush();
-    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey');
+    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey', function($success) {
+      $this->assertFalse($success);
+    });
     $webPush->sendNotifications();
   }
 
@@ -116,7 +126,9 @@ class SendNotificationTest extends WP_UnitTestCase {
     });
 
     $webPush = new WebPush();
-    $webPush->addRecipient('endpoint', false, 'aKey');
+    $webPush->addRecipient('endpoint', false, 'aKey', function($success) {
+      $this->assertTrue($success);
+    });
     $webPush->sendNotifications();
   }
 }

--- a/tests/test-send-notification.php
+++ b/tests/test-send-notification.php
@@ -30,54 +30,29 @@ class SendNotificationTest extends WP_UnitTestCase {
     $webPush->sendNotifications();
   }
 
-  /*function test_send_gcm_notification_success() {
-    $self = $this;
-    add_filter('pre_http_request', function($url, $r) use ($self) {
-      $self->assertEquals('key=aKey', $r['headers']['Authorization']);
-      $self->assertEquals('application/json', $r['headers']['Content-Type']);
-      $self->assertEquals(33, $r['headers']['Content-Length']);
-
-      $data = json_decode($r['body']);
-      $self->assertEquals(1, count($data->registration_ids));
-      $self->assertEquals('endpoint', $data->registration_ids[0]);
-
-      return array(
-        'headers' => array(),
-        'body' => '',
-        'response' => array(
-          'code' => 200,
-        ),
-        'cookies' => array(),
-        'filename' => '',
-      );
-    }, 10, 2);
-
+  function test_send_gcm_notification_success() {
     $webPush = new WebPush();
+    $self = $this;
     $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey', function($success) use ($self) {
-      $this->assertTrue($success);
+      $self->assertTrue($success);
     });
+
+    $webPush->requests[0]['url'] = 'http://localhost:55555/200/gcm';
+
     $webPush->sendNotifications();
   }
 
   function test_send_gcm_notification_failure() {
-    add_filter('pre_http_request', function() {
-      return array(
-        'headers' => array(),
-        'body' => '',
-        'response' => array(
-          'code' => 400,
-        ),
-        'cookies' => array(),
-        'filename' => '',
-      );
+    $webPush = new WebPush();
+    $self = $this;
+    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey', function($success) use ($self) {
+      $self->assertFalse($success);
     });
 
-    $webPush = new WebPush();
-    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey', function($success) {
-      $this->assertFalse($success);
-    });
+    $webPush->requests[0]['url'] = 'http://localhost:55555/400/gcm';
+
     $webPush->sendNotifications();
-  }*/
+  }
 
   /*function test_send_notification_error() {
     add_filter('pre_http_request', function() {

--- a/tests/test-send-notification.php
+++ b/tests/test-send-notification.php
@@ -3,77 +3,34 @@
 require_once dirname(dirname(__FILE__)) . '/build/web-push.php';
 
 class SendNotificationTest extends WP_UnitTestCase {
-  function tearDown() {
-    parent::tearDown();
-    remove_all_filters('pre_http_request');
-  }
-
   function test_send_webpush_notification_success() {
-    $self = $this;
-    add_filter('pre_http_request', function($url, $r) use ($self) {
-      $self->assertTrue($r['headers']['TTL'] > 0);
-
-      return array(
-        'headers' => array(),
-        'body' => '',
-        'response' => array(
-          'code' => 201,
-        ),
-        'cookies' => array(),
-        'filename' => '',
-      );
-    }, 10, 2);
-
     $webPush = new WebPush();
-    $webPush->addRecipient('endpoint', false, 'aKey', function($success) use ($self) {
+    $self = $this;
+    $webPush->addRecipient('http://localhost:55555/201', false, 'aKey', function($success) use ($self) {
       $self->assertTrue($success);
     });
     $webPush->sendNotifications();
   }
 
   function test_send_webpush_notification_success_no_key() {
-    add_filter('pre_http_request', function() {
-      return array(
-        'headers' => array(),
-        'body' => '',
-        'response' => array(
-          'code' => 201,
-        ),
-        'cookies' => array(),
-        'filename' => '',
-      );
-    });
-
     $webPush = new WebPush();
     $self = $this;
-    $webPush->addRecipient('endpoint', false, '', function($success) use ($self) {
+    $webPush->addRecipient('http://localhost:55555/201', false, '', function($success) use ($self) {
       $self->assertTrue($success);
     });
     $webPush->sendNotifications();
   }
 
   function test_send_webpush_notification_failure() {
-    add_filter('pre_http_request', function() {
-      return array(
-        'headers' => array(),
-        'body' => '',
-        'response' => array(
-          'code' => 400,
-        ),
-        'cookies' => array(),
-        'filename' => '',
-      );
-    });
-
     $webPush = new WebPush();
     $self = $this;
-    $webPush->addRecipient('endpoint', false, 'aKey', function($success) use ($self) {
+    $webPush->addRecipient('http://localhost:55555/400', false, 'aKey', function($success) use ($self) {
       $self->assertFalse($success);
     });
     $webPush->sendNotifications();
   }
 
-  function test_send_gcm_notification_success() {
+  /*function test_send_gcm_notification_success() {
     $self = $this;
     add_filter('pre_http_request', function($url, $r) use ($self) {
       $self->assertEquals('key=aKey', $r['headers']['Authorization']);
@@ -120,9 +77,9 @@ class SendNotificationTest extends WP_UnitTestCase {
       $this->assertFalse($success);
     });
     $webPush->sendNotifications();
-  }
+  }*/
 
-  function test_send_notification_error() {
+  /*function test_send_notification_error() {
     add_filter('pre_http_request', function() {
       return new WP_Error('Error');
     });
@@ -132,7 +89,7 @@ class SendNotificationTest extends WP_UnitTestCase {
       $this->assertTrue($success);
     });
     $webPush->sendNotifications();
-  }
+  }*/
 }
 
 ?>

--- a/tests/test-send-notification.php
+++ b/tests/test-send-notification.php
@@ -4,12 +4,16 @@ require_once dirname(dirname(__FILE__)) . '/build/web-push.php';
 
 class SendNotificationTest extends WP_UnitTestCase {
   function send_webpush_notification_success($forceWP) {
+    $oldNum = getSentNotificationNum();
+
     $webPush = new WebPush($forceWP);
     $self = $this;
     $webPush->addRecipient('http://localhost:55555/201', false, 'aKey', function($success) use ($self) {
       $self->assertTrue($success);
     });
     $webPush->sendNotifications();
+
+    $this->assertEquals($oldNum + 1, getSentNotificationNum());
   }
 
   function test_send_webpush_notification_success() {
@@ -18,12 +22,16 @@ class SendNotificationTest extends WP_UnitTestCase {
   }
 
   function send_webpush_notification_success_no_key($forceWP) {
+    $oldNum = getSentNotificationNum();
+
     $webPush = new WebPush($forceWP);
     $self = $this;
     $webPush->addRecipient('http://localhost:55555/201', false, '', function($success) use ($self) {
       $self->assertTrue($success);
     });
     $webPush->sendNotifications();
+
+    $this->assertEquals($oldNum + 1, getSentNotificationNum());
   }
 
   function test_send_webpush_notification_success_no_key() {
@@ -32,12 +40,16 @@ class SendNotificationTest extends WP_UnitTestCase {
   }
 
   function send_webpush_notification_failure($forceWP) {
+    $oldNum = getSentNotificationNum();
+
     $webPush = new WebPush($forceWP);
     $self = $this;
     $webPush->addRecipient('http://localhost:55555/400', false, 'aKey', function($success) use ($self) {
       $self->assertFalse($success);
     });
     $webPush->sendNotifications();
+
+    $this->assertEquals($oldNum + 1, getSentNotificationNum());
   }
 
   function test_send_webpush_notification_failure() {
@@ -46,6 +58,8 @@ class SendNotificationTest extends WP_UnitTestCase {
   }
 
   function send_gcm_notification_success($forceWP) {
+    $oldNum = getSentNotificationNum();
+
     $webPush = new WebPush($forceWP);
     $self = $this;
     $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey', function($success) use ($self) {
@@ -55,6 +69,8 @@ class SendNotificationTest extends WP_UnitTestCase {
     $webPush->requests[0]['url'] = 'http://localhost:55555/200/gcm';
 
     $webPush->sendNotifications();
+
+    $this->assertEquals($oldNum + 1, getSentNotificationNum());
   }
 
   function test_send_gcm_notification_success() {
@@ -63,6 +79,8 @@ class SendNotificationTest extends WP_UnitTestCase {
   }
 
   function send_gcm_notification_failure($forceWP) {
+    $oldNum = getSentNotificationNum();
+
     $webPush = new WebPush($forceWP);
     $self = $this;
     $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey', function($success) use ($self) {
@@ -72,6 +90,8 @@ class SendNotificationTest extends WP_UnitTestCase {
     $webPush->requests[0]['url'] = 'http://localhost:55555/400/gcm';
 
     $webPush->sendNotifications();
+
+    $this->assertEquals($oldNum + 1, getSentNotificationNum());
   }
 
   function test_send_gcm_notification_failure() {
@@ -80,6 +100,8 @@ class SendNotificationTest extends WP_UnitTestCase {
   }
 
   function test_send_notification_error() {
+    $oldNum = getSentNotificationNum();
+
     add_filter('pre_http_request', function() {
       return new WP_Error('Error');
     });
@@ -90,15 +112,19 @@ class SendNotificationTest extends WP_UnitTestCase {
       $self->assertTrue($success);
     });
     $webPush->sendNotifications();
+
+    $this->assertEquals($oldNum, getSentNotificationNum());
   }
 
   function send_multiple_notifications_success($forceWP) {
+    $oldNum = getSentNotificationNum();
+
     $webPush = new WebPush($forceWP);
     $self = $this;
     $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey', function($success) use ($self) {
       $self->assertTrue($success);
     });
-    $webPush->addRecipient('http://localhost:55555/400', true, 'aKey', function($success) use ($self) {
+    $webPush->addRecipient('http://localhost:55555/400', false, 'aKey', function($success) use ($self) {
       $self->assertFalse($success);
     });
     $webPush->addRecipient('http://localhost:55555/201', false, 'aKey', function($success) use ($self) {
@@ -108,6 +134,8 @@ class SendNotificationTest extends WP_UnitTestCase {
     $webPush->requests[0]['url'] = 'http://localhost:55555/200/gcm';
 
     $webPush->sendNotifications();
+
+    $this->assertEquals($oldNum + 3, getSentNotificationNum());
   }
 
   function test_send_multiple_notifications_success() {

--- a/tests/test-send-notification.php
+++ b/tests/test-send-notification.php
@@ -79,17 +79,17 @@ class SendNotificationTest extends WP_UnitTestCase {
     $this->send_gcm_notification_failure(true);
   }
 
-  /*function test_send_notification_error() {
+  function test_send_notification_error() {
     add_filter('pre_http_request', function() {
       return new WP_Error('Error');
     });
 
-    $webPush = new WebPush();
+    $webPush = new WebPush(true);
     $webPush->addRecipient('endpoint', false, 'aKey', function($success) {
       $this->assertTrue($success);
     });
     $webPush->sendNotifications();
-  }*/
+  }
 }
 
 ?>

--- a/tests/test-send-notification.php
+++ b/tests/test-send-notification.php
@@ -25,8 +25,8 @@ class SendNotificationTest extends WP_UnitTestCase {
     }, 10, 2);
 
     $webPush = new WebPush();
-    $webPush->addRecipient('endpoint', false, 'aKey', function($success) {
-      $this->assertTrue($success);
+    $webPush->addRecipient('endpoint', false, 'aKey', function($success) use ($self) {
+      $self->assertTrue($success);
     });
     $webPush->sendNotifications();
   }
@@ -45,8 +45,9 @@ class SendNotificationTest extends WP_UnitTestCase {
     });
 
     $webPush = new WebPush();
-    $webPush->addRecipient('endpoint', false, '', function($success) {
-      $this->assertTrue($success);
+    $self = $this;
+    $webPush->addRecipient('endpoint', false, '', function($success) use ($self) {
+      $self->assertTrue($success);
     });
     $webPush->sendNotifications();
   }
@@ -65,8 +66,9 @@ class SendNotificationTest extends WP_UnitTestCase {
     });
 
     $webPush = new WebPush();
-    $webPush->addRecipient('endpoint', false, 'aKey', function($success) {
-      $this->assertFalse($success);
+    $self = $this;
+    $webPush->addRecipient('endpoint', false, 'aKey', function($success) use ($self) {
+      $self->assertFalse($success);
     });
     $webPush->sendNotifications();
   }
@@ -94,7 +96,7 @@ class SendNotificationTest extends WP_UnitTestCase {
     }, 10, 2);
 
     $webPush = new WebPush();
-    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey', function($success) {
+    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey', function($success) use ($self) {
       $this->assertTrue($success);
     });
     $webPush->sendNotifications();

--- a/tests/test-send-notification.php
+++ b/tests/test-send-notification.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once dirname(dirname(__FILE__)) . '/build/web-push.php';
+
 class SendNotificationTest extends WP_UnitTestCase {
   function tearDown() {
     parent::tearDown();
@@ -22,26 +24,9 @@ class SendNotificationTest extends WP_UnitTestCase {
       );
     }, 10, 2);
 
-    $this->assertTrue(sendNotification('endpoint', false, 'aKey', true));
-  }
-
-  function test_send_webpush_notification_async() {
-    $self = $this;
-    add_filter('pre_http_request', function($url, $r) use ($self) {
-      $self->assertTrue($r['headers']['TTL'] > 0);
-
-      return array(
-        'headers' => array(),
-        'body' => '',
-        'response' => array(
-          'code' => 201,
-        ),
-        'cookies' => array(),
-        'filename' => '',
-      );
-    }, 10, 2);
-
-    $this->assertTrue(sendNotification('endpoint', false, 'aKey', false));
+    $webPush = new WebPush();
+    $webPush->addRecipient('endpoint', false, 'aKey');
+    $webPush->sendNotifications();
   }
 
   function test_send_webpush_notification_success_no_key() {
@@ -57,7 +42,9 @@ class SendNotificationTest extends WP_UnitTestCase {
       );
     });
 
-    $this->assertTrue(sendNotification('endpoint', false, '', true));
+    $webPush = new WebPush();
+    $webPush->addRecipient('endpoint', false, '');
+    $webPush->sendNotifications();
   }
 
   function test_send_webpush_notification_failure() {
@@ -73,7 +60,9 @@ class SendNotificationTest extends WP_UnitTestCase {
       );
     });
 
-    $this->assertFalse(sendNotification('endpoint', false, 'aKey', true));
+    $webPush = new WebPush();
+    $webPush->addRecipient('endpoint', false, 'aKey');
+    $webPush->sendNotifications();
   }
 
   function test_send_gcm_notification_success() {
@@ -98,7 +87,9 @@ class SendNotificationTest extends WP_UnitTestCase {
       );
     }, 10, 2);
 
-    $this->assertTrue(sendNotification('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey', true));
+    $webPush = new WebPush();
+    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey');
+    $webPush->sendNotifications();
   }
 
   function test_send_gcm_notification_failure() {
@@ -114,7 +105,9 @@ class SendNotificationTest extends WP_UnitTestCase {
       );
     });
 
-    $this->assertFalse(sendNotification('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey', true));
+    $webPush = new WebPush();
+    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey');
+    $webPush->sendNotifications();
   }
 
   function test_send_notification_error() {
@@ -122,7 +115,9 @@ class SendNotificationTest extends WP_UnitTestCase {
       return new WP_Error('Error');
     });
 
-    $this->assertTrue(sendNotification('endpoint', false, 'aKey', true));
+    $webPush = new WebPush();
+    $webPush->addRecipient('endpoint', false, 'aKey');
+    $webPush->sendNotifications();
   }
 }
 

--- a/tests/test-send-notification.php
+++ b/tests/test-send-notification.php
@@ -90,6 +90,29 @@ class SendNotificationTest extends WP_UnitTestCase {
     });
     $webPush->sendNotifications();
   }
+
+  function send_multiple_notifications_success($forceWP) {
+    $webPush = new WebPush($forceWP);
+    $self = $this;
+    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', true, 'aKey', function($success) use ($self) {
+      $self->assertTrue($success);
+    });
+    $webPush->addRecipient('http://localhost:55555/400', true, 'aKey', function($success) use ($self) {
+      $self->assertFalse($success);
+    });
+    $webPush->addRecipient('http://localhost:55555/201', false, 'aKey', function($success) use ($self) {
+      $self->assertTrue($success);
+    });
+
+    $webPush->requests[0]['url'] = 'http://localhost:55555/200/gcm';
+
+    $webPush->sendNotifications();
+  }
+
+  function test_send_multiple_notifications_success() {
+    $this->send_multiple_notifications_success(false);
+    $this->send_multiple_notifications_success(true);
+  }
 }
 
 ?>

--- a/tests/test-send-notification.php
+++ b/tests/test-send-notification.php
@@ -85,8 +85,9 @@ class SendNotificationTest extends WP_UnitTestCase {
     });
 
     $webPush = new WebPush(true);
-    $webPush->addRecipient('endpoint', false, 'aKey', function($success) {
-      $this->assertTrue($success);
+    $self = $this;
+    $webPush->addRecipient('endpoint', false, 'aKey', function($success) use ($self) {
+      $self->assertTrue($success);
     });
     $webPush->sendNotifications();
   }

--- a/tests/test-send-notification.php
+++ b/tests/test-send-notification.php
@@ -7,8 +7,9 @@ class SendNotificationTest extends WP_UnitTestCase {
     $oldNum = getSentNotificationNum();
 
     $webPush = new WebPush($forceWP);
+    $webPush->setGCMKey('aKey');
     $self = $this;
-    $webPush->addRecipient('http://localhost:55555/201', 'aKey', function($success) use ($self) {
+    $webPush->addRecipient('http://localhost:55555/201', function($success) use ($self) {
       $self->assertTrue($success);
     });
     $webPush->sendNotifications();
@@ -26,7 +27,7 @@ class SendNotificationTest extends WP_UnitTestCase {
 
     $webPush = new WebPush($forceWP);
     $self = $this;
-    $webPush->addRecipient('http://localhost:55555/201', '', function($success) use ($self) {
+    $webPush->addRecipient('http://localhost:55555/201', function($success) use ($self) {
       $self->assertTrue($success);
     });
     $webPush->sendNotifications();
@@ -44,7 +45,7 @@ class SendNotificationTest extends WP_UnitTestCase {
 
     $webPush = new WebPush($forceWP);
     $self = $this;
-    $webPush->addRecipient('http://localhost:55555/400', 'aKey', function($success) use ($self) {
+    $webPush->addRecipient('http://localhost:55555/400', function($success) use ($self) {
       $self->assertFalse($success);
     });
     $webPush->sendNotifications();
@@ -61,8 +62,9 @@ class SendNotificationTest extends WP_UnitTestCase {
     $oldNum = getSentNotificationNum();
 
     $webPush = new WebPush($forceWP);
+    $webPush->setGCMKey('aKey');
     $self = $this;
-    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', 'aKey', function($success) use ($self) {
+    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', function($success) use ($self) {
       $self->assertTrue($success);
     });
 
@@ -82,8 +84,9 @@ class SendNotificationTest extends WP_UnitTestCase {
     $oldNum = getSentNotificationNum();
 
     $webPush = new WebPush($forceWP);
+    $webPush->setGCMKey('aKey');
     $self = $this;
-    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', 'aKey', function($success) use ($self) {
+    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', function($success) use ($self) {
       $self->assertFalse($success);
     });
 
@@ -108,7 +111,7 @@ class SendNotificationTest extends WP_UnitTestCase {
 
     $webPush = new WebPush(true);
     $self = $this;
-    $webPush->addRecipient('endpoint', 'aKey', function($success) use ($self) {
+    $webPush->addRecipient('endpoint', function($success) use ($self) {
       $self->assertTrue($success);
     });
     $webPush->sendNotifications();
@@ -120,14 +123,15 @@ class SendNotificationTest extends WP_UnitTestCase {
     $oldNum = getSentNotificationNum();
 
     $webPush = new WebPush($forceWP);
+    $webPush->setGCMKey('aKey');
     $self = $this;
-    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', 'aKey', function($success) use ($self) {
+    $webPush->addRecipient('https://android.googleapis.com/gcm/send/endpoint', function($success) use ($self) {
       $self->assertTrue($success);
     });
-    $webPush->addRecipient('http://localhost:55555/400', 'aKey', function($success) use ($self) {
+    $webPush->addRecipient('http://localhost:55555/400', function($success) use ($self) {
       $self->assertFalse($success);
     });
-    $webPush->addRecipient('http://localhost:55555/201', 'aKey', function($success) use ($self) {
+    $webPush->addRecipient('http://localhost:55555/201', function($success) use ($self) {
       $self->assertTrue($success);
     });
 

--- a/tests/test-transition-post-status.php
+++ b/tests/test-transition-post-status.php
@@ -231,25 +231,10 @@ class TransitionPostStatusTest extends WP_UnitTestCase {
     $this->assertEquals($oldNum + 2, getSentNotificationNum());
   }
 
-  /*function test_success_no_gcm_key() {
+  function test_success_no_gcm_key() {
     $oldNum = getSentNotificationNum();
 
     WebPush_DB::add_subscription('https://android.googleapis.com/gcm/send/endpoint', '');
-
-    $self = $this;
-    add_filter('pre_http_request', function() use ($self) {
-      $self->assertTrue(true);
-
-      return array(
-        'headers' => array(),
-        'body' => '',
-        'response' => array(
-          'code' => 201,
-        ),
-        'cookies' => array(),
-        'filename' => '',
-      );
-    });
 
     $post = get_post($this->factory->post->create(array('post_title' => 'Test Post Title')));
     $main = new WebPush_Main();
@@ -269,51 +254,11 @@ class TransitionPostStatusTest extends WP_UnitTestCase {
     // Test that the GCM endpoint isn't removed.
     $subscriptions = WebPush_DB::get_subscriptions();
     $this->assertEquals(2, count($subscriptions));
-    $this->assertEquals('endpoint', $subscriptions[0]->endpoint);
+    $this->assertEquals('http://localhost:55555/201', $subscriptions[0]->endpoint);
     $this->assertEquals('aKey', $subscriptions[0]->userKey);
     $this->assertEquals('https://android.googleapis.com/gcm/send/endpoint', $subscriptions[1]->endpoint);
     $this->assertEquals('', $subscriptions[1]->userKey);
   }
-
-  function test_success_with_gcm_key() {
-    $oldNum = getSentNotificationNum();
-
-    WebPush_DB::add_subscription('https://android.googleapis.com/gcm/send/endpoint', '');
-
-    $self = $this;
-    add_filter('pre_http_request', function($url, $r) use ($self) {
-      $self->assertTrue(true);
-
-      $code = isset($r['headers']['TTL']) ? 201 : 200;
-
-      return array(
-        'headers' => array(),
-        'body' => '',
-        'response' => array(
-          'code' => $code,
-        ),
-        'cookies' => array(),
-        'filename' => '',
-      );
-    }, 10, 2);
-
-    update_option('webpush_gcm_key', 'ASD');
-
-    $post = get_post($this->factory->post->create(array('post_title' => 'Test Post Title')));
-    $main = new WebPush_Main();
-    $main->on_transition_post_status('publish', 'draft', $post);
-
-    $payload = get_option('webpush_payload');
-    $this->assertEquals('Test Blog', $payload['title']);
-    $this->assertEquals('Test Post Title', $payload['body']);
-    $this->assertEquals('', $payload['icon']);
-    $this->assertEquals('http://example.org/?p=' . $post->ID, $payload['url']);
-    $this->assertEquals($post->ID, $payload['postID']);
-    $this->assertEquals(0, get_post_meta($post->ID, '_notifications_clicked', true));
-    $this->assertEquals(2, get_post_meta($post->ID, '_notifications_sent', true));
-
-    $this->assertEquals($oldNum + 2, getSentNotificationNum());
-  }*/
 
   function test_success_remove_invalid_subscription() {
     $oldNum = getSentNotificationNum();

--- a/tests/test-transition-post-status.php
+++ b/tests/test-transition-post-status.php
@@ -4,97 +4,79 @@ class TransitionPostStatusTest extends WP_UnitTestCase {
   function setUp() {
     parent::setUp();
 
-    WebPush_DB::add_subscription('endpoint', 'aKey');
+    WebPush_DB::add_subscription('http://localhost:55555/201', 'aKey');
 
     $_REQUEST['webpush_meta_box_nonce'] = wp_create_nonce('webpush_send_notification');
     $_REQUEST['webpush_send_notification'] = 1;
   }
 
-  function tearDown() {
-    parent::tearDown();
-    remove_all_filters('pre_http_request');
-  }
-
   function test_empty_post() {
-    add_filter('pre_http_request', function() {
-      $self->assertTrue(false);
-    });
+    $oldNum = getSentNotificationNum();
 
     $main = new WebPush_Main();
     $main->on_transition_post_status('publish', 'draft', null);
+
+    $this->assertEquals($oldNum, getSentNotificationNum());
   }
 
   function test_non_post() {
-    add_filter('pre_http_request', function() {
-      $self->assertTrue(false);
-    });
+    $oldNum = getSentNotificationNum();
 
     $post = get_post($this->factory->post->create(array('post_type' => 'page')));
     $main = new WebPush_Main();
     $main->on_transition_post_status('publish', 'draft', $post);
+
+    $this->assertEquals($oldNum, getSentNotificationNum());
   }
 
   function test_non_published() {
-    add_filter('pre_http_request', function() {
-      $self->assertTrue(false);
-    });
+    $oldNum = getSentNotificationNum();
 
     $post = get_post($this->factory->post->create());
     $main = new WebPush_Main();
     $main->on_transition_post_status('draft', 'draft', $post);
+
+    $this->assertEquals($oldNum, getSentNotificationNum());
   }
 
   function test_nonce_not_set() {
-    add_filter('pre_http_request', function() {
-      $self->assertTrue(false);
-    });
+    $oldNum = getSentNotificationNum();
 
     unset($_REQUEST['webpush_meta_box_nonce']);
 
     $post = get_post($this->factory->post->create());
     $main = new WebPush_Main();
     $main->on_transition_post_status('publish', 'draft', $post);
+
+    $this->assertEquals($oldNum, getSentNotificationNum());
   }
 
   function test_invalid_nonce() {
-    add_filter('pre_http_request', function() {
-      $self->assertTrue(false);
-    });
+    $oldNum = getSentNotificationNum();
 
     $_REQUEST['webpush_meta_box_nonce'] = 'invalid';
 
     $post = get_post($this->factory->post->create());
     $main = new WebPush_Main();
     $main->on_transition_post_status('publish', 'draft', $post);
+
+    $this->assertEquals($oldNum, getSentNotificationNum());
   }
 
   function test_checkbox_not_set() {
-    add_filter('pre_http_request', function() {
-      $self->assertTrue(false);
-    });
+    $oldNum = getSentNotificationNum();
 
     unset($_REQUEST['webpush_send_notification']);
 
     $post = get_post($this->factory->post->create());
     $main = new WebPush_Main();
     $main->on_transition_post_status('publish', 'draft', $post);
+
+    $this->assertEquals($oldNum, getSentNotificationNum());
   }
 
   function test_success() {
-    $self = $this;
-    add_filter('pre_http_request', function() use ($self) {
-      $self->assertTrue(true);
-
-      return array(
-        'headers' => array(),
-        'body' => '',
-        'response' => array(
-          'code' => 201,
-        ),
-        'cookies' => array(),
-        'filename' => '',
-      );
-    });
+    $oldNum = getSentNotificationNum();
 
     $post = get_post($this->factory->post->create(array('post_title' => 'Test Post Title')));
     $main = new WebPush_Main();
@@ -108,23 +90,12 @@ class TransitionPostStatusTest extends WP_UnitTestCase {
     $this->assertEquals($post->ID, $payload['postID']);
     $this->assertEquals(0, get_post_meta($post->ID, '_notifications_clicked', true));
     $this->assertEquals(1, get_post_meta($post->ID, '_notifications_sent', true));
+
+    $this->assertEquals($oldNum + 1, getSentNotificationNum());
   }
 
   function test_success_custom_title() {
-    $self = $this;
-    add_filter('pre_http_request', function() use ($self) {
-      $self->assertTrue(true);
-
-      return array(
-        'headers' => array(),
-        'body' => '',
-        'response' => array(
-          'code' => 201,
-        ),
-        'cookies' => array(),
-        'filename' => '',
-      );
-    });
+    $oldNum = getSentNotificationNum();
 
     update_option('webpush_title', 'A Custom Title');
 
@@ -140,23 +111,12 @@ class TransitionPostStatusTest extends WP_UnitTestCase {
     $this->assertEquals($post->ID, $payload['postID']);
     $this->assertEquals(0, get_post_meta($post->ID, '_notifications_clicked', true));
     $this->assertEquals(1, get_post_meta($post->ID, '_notifications_sent', true));
+
+    $this->assertEquals($oldNum + 1, getSentNotificationNum());
   }
 
   function test_success_custom_icon() {
-    $self = $this;
-    add_filter('pre_http_request', function() use ($self) {
-      $self->assertTrue(true);
-
-      return array(
-        'headers' => array(),
-        'body' => '',
-        'response' => array(
-          'code' => 201,
-        ),
-        'cookies' => array(),
-        'filename' => '',
-      );
-    });
+    $oldNum = getSentNotificationNum();
 
     update_option('webpush_icon', 'https://www.mozilla.org/icon.svg');
 
@@ -172,23 +132,12 @@ class TransitionPostStatusTest extends WP_UnitTestCase {
     $this->assertEquals($post->ID, $payload['postID']);
     $this->assertEquals(0, get_post_meta($post->ID, '_notifications_clicked', true));
     $this->assertEquals(1, get_post_meta($post->ID, '_notifications_sent', true));
+
+    $this->assertEquals($oldNum + 1, getSentNotificationNum());
   }
 
   function test_success_no_icon() {
-    $self = $this;
-    add_filter('pre_http_request', function() use ($self) {
-      $self->assertTrue(true);
-
-      return array(
-        'headers' => array(),
-        'body' => '',
-        'response' => array(
-          'code' => 201,
-        ),
-        'cookies' => array(),
-        'filename' => '',
-      );
-    });
+    $oldNum = getSentNotificationNum();
 
     update_option('webpush_icon', '');
 
@@ -204,23 +153,12 @@ class TransitionPostStatusTest extends WP_UnitTestCase {
     $this->assertEquals($post->ID, $payload['postID']);
     $this->assertEquals(0, get_post_meta($post->ID, '_notifications_clicked', true));
     $this->assertEquals(1, get_post_meta($post->ID, '_notifications_sent', true));
+
+    $this->assertEquals($oldNum + 1, getSentNotificationNum());
   }
 
   function test_success_post_thumbnail_icon() {
-    $self = $this;
-    add_filter('pre_http_request', function() use ($self) {
-      $self->assertTrue(true);
-
-      return array(
-        'headers' => array(),
-        'body' => '',
-        'response' => array(
-          'code' => 201,
-        ),
-        'cookies' => array(),
-        'filename' => '',
-      );
-    });
+    $oldNum = getSentNotificationNum();
 
     update_option('webpush_icon', 'post_icon');
 
@@ -241,23 +179,12 @@ class TransitionPostStatusTest extends WP_UnitTestCase {
     $this->assertEquals($postID, $payload['postID']);
     $this->assertEquals(0, get_post_meta($postID, '_notifications_clicked', true));
     $this->assertEquals(1, get_post_meta($postID, '_notifications_sent', true));
+
+    $this->assertEquals($oldNum + 1, getSentNotificationNum());
   }
 
   function test_success_site_icon() {
-    $self = $this;
-    add_filter('pre_http_request', function() use ($self) {
-      $self->assertTrue(true);
-
-      return array(
-        'headers' => array(),
-        'body' => '',
-        'response' => array(
-          'code' => 201,
-        ),
-        'cookies' => array(),
-        'filename' => '',
-      );
-    });
+    $oldNum = getSentNotificationNum();
 
     update_option('webpush_icon', 'blog_icon');
 
@@ -279,25 +206,14 @@ class TransitionPostStatusTest extends WP_UnitTestCase {
     $this->assertEquals($post->ID, $payload['postID']);
     $this->assertEquals(0, get_post_meta($post->ID, '_notifications_clicked', true));
     $this->assertEquals(1, get_post_meta($post->ID, '_notifications_sent', true));
+
+    $this->assertEquals($oldNum + 1, getSentNotificationNum());
   }
 
   function test_success_multiple_subscribers() {
-    WebPush_DB::add_subscription('endpoint2', 'aKey2');
+    $oldNum = getSentNotificationNum();
 
-    $self = $this;
-    add_filter('pre_http_request', function() use ($self) {
-      $self->assertTrue(true);
-
-      return array(
-        'headers' => array(),
-        'body' => '',
-        'response' => array(
-          'code' => 201,
-        ),
-        'cookies' => array(),
-        'filename' => '',
-      );
-    });
+    WebPush_DB::add_subscription('http://localhost:55555/200', 'aKey2');
 
     $post = get_post($this->factory->post->create(array('post_title' => 'Test Post Title')));
     $main = new WebPush_Main();
@@ -311,9 +227,13 @@ class TransitionPostStatusTest extends WP_UnitTestCase {
     $this->assertEquals($post->ID, $payload['postID']);
     $this->assertEquals(0, get_post_meta($post->ID, '_notifications_clicked', true));
     $this->assertEquals(2, get_post_meta($post->ID, '_notifications_sent', true));
+
+    $this->assertEquals($oldNum + 2, getSentNotificationNum());
   }
 
-  function test_success_no_gcm_key() {
+  /*function test_success_no_gcm_key() {
+    $oldNum = getSentNotificationNum();
+
     WebPush_DB::add_subscription('https://android.googleapis.com/gcm/send/endpoint', '');
 
     $self = $this;
@@ -344,6 +264,8 @@ class TransitionPostStatusTest extends WP_UnitTestCase {
     $this->assertEquals(0, get_post_meta($post->ID, '_notifications_clicked', true));
     $this->assertEquals(1, get_post_meta($post->ID, '_notifications_sent', true));
 
+    $this->assertEquals($oldNum + 1, getSentNotificationNum());
+
     // Test that the GCM endpoint isn't removed.
     $subscriptions = WebPush_DB::get_subscriptions();
     $this->assertEquals(2, count($subscriptions));
@@ -354,6 +276,8 @@ class TransitionPostStatusTest extends WP_UnitTestCase {
   }
 
   function test_success_with_gcm_key() {
+    $oldNum = getSentNotificationNum();
+
     WebPush_DB::add_subscription('https://android.googleapis.com/gcm/send/endpoint', '');
 
     $self = $this;
@@ -387,35 +311,14 @@ class TransitionPostStatusTest extends WP_UnitTestCase {
     $this->assertEquals($post->ID, $payload['postID']);
     $this->assertEquals(0, get_post_meta($post->ID, '_notifications_clicked', true));
     $this->assertEquals(2, get_post_meta($post->ID, '_notifications_sent', true));
-  }
+
+    $this->assertEquals($oldNum + 2, getSentNotificationNum());
+  }*/
 
   function test_success_remove_invalid_subscription() {
-    global $i;
-    $i = 0;
+    $oldNum = getSentNotificationNum();
 
-    WebPush_DB::add_subscription('endpoint2', 'aKey2');
-
-    $self = $this;
-    add_filter('pre_http_request', function() use ($self) {
-      global $i;
-
-      $self->assertTrue(true);
-
-      $code = 201;
-      if ($i++ === 1) {
-        $code = 404;
-      }
-
-      return array(
-        'headers' => array(),
-        'body' => '',
-        'response' => array(
-          'code' => $code,
-        ),
-        'cookies' => array(),
-        'filename' => '',
-      );
-    });
+    WebPush_DB::add_subscription('http://localhost:55555/400', 'aKey2');
 
     $post = get_post($this->factory->post->create(array('post_title' => 'Test Post Title')));
     $main = new WebPush_Main();
@@ -430,10 +333,12 @@ class TransitionPostStatusTest extends WP_UnitTestCase {
     $this->assertEquals(0, get_post_meta($post->ID, '_notifications_clicked', true));
     $this->assertEquals(1, get_post_meta($post->ID, '_notifications_sent', true));
 
+    $this->assertEquals($oldNum + 2, getSentNotificationNum());
+
     // Test that the invalid subscription gets removed.
     $subscriptions = WebPush_DB::get_subscriptions();
     $this->assertEquals(1, count($subscriptions));
-    $this->assertEquals('endpoint', $subscriptions[0]->endpoint);
+    $this->assertEquals('http://localhost:55555/201', $subscriptions[0]->endpoint);
     $this->assertEquals('aKey', $subscriptions[0]->userKey);
   }
 }

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -1,0 +1,7 @@
+<?php
+
+function getSentNotificationNum() {
+  return intval(file_get_contents('http://localhost:55555/'));
+}
+
+?>

--- a/wp-web-push/class-wp-http-curl-multi.php
+++ b/wp-web-push/class-wp-http-curl-multi.php
@@ -1,0 +1,376 @@
+<?php
+/**
+ * HTTP API: WP_Http_Curl class
+ *
+ * @package WordPress
+ * @subpackage HTTP
+ * @since 4.4.0
+ */
+
+/**
+ * Core class used to integrate Curl as an HTTP transport.
+ *
+ * HTTP request method uses Curl extension to retrieve the url.
+ *
+ * Requires the Curl extension to be installed.
+ *
+ * @since 2.7.0
+ */
+class WP_Http_Curl {
+
+	/**
+	 * Temporary header storage for during requests.
+	 *
+	 * @since 3.2.0
+	 * @access private
+	 * @var string
+	 */
+	private $headers = '';
+
+	/**
+	 * Temporary body storage for during requests.
+	 *
+	 * @since 3.6.0
+	 * @access private
+	 * @var string
+	 */
+	private $body = '';
+
+	/**
+	 * The maximum amount of data to receive from the remote server.
+	 *
+	 * @since 3.6.0
+	 * @access private
+	 * @var int
+	 */
+	private $max_body_length = false;
+
+	/**
+	 * The file resource used for streaming to file.
+	 *
+	 * @since 3.6.0
+	 * @access private
+	 * @var resource
+	 */
+	private $stream_handle = false;
+
+	/**
+	 * The total bytes written in the current request.
+	 *
+	 * @since 4.1.0
+	 * @access private
+	 * @var int
+	 */
+	private $bytes_written_total = 0;
+
+	/**
+	 * Send a HTTP request to a URI using cURL extension.
+	 *
+	 * @access public
+	 * @since 2.7.0
+	 *
+	 * @param string $url The request URL.
+	 * @param string|array $args Optional. Override the defaults.
+	 * @return array|WP_Error Array containing 'headers', 'body', 'response', 'cookies', 'filename'. A WP_Error instance upon error
+	 */
+	public function request($url, $args = array()) {
+		$defaults = array(
+			'method' => 'GET', 'timeout' => 5,
+			'redirection' => 5, 'httpversion' => '1.0',
+			'blocking' => true,
+			'headers' => array(), 'body' => null, 'cookies' => array()
+		);
+
+		$r = wp_parse_args( $args, $defaults );
+
+		if ( isset( $r['headers']['User-Agent'] ) ) {
+			$r['user-agent'] = $r['headers']['User-Agent'];
+			unset( $r['headers']['User-Agent'] );
+		} elseif ( isset( $r['headers']['user-agent'] ) ) {
+			$r['user-agent'] = $r['headers']['user-agent'];
+			unset( $r['headers']['user-agent'] );
+		}
+
+		// Construct Cookie: header if any cookies are set.
+		WP_Http::buildCookieHeader( $r );
+
+		$handle = curl_init();
+
+		// cURL offers really easy proxy support.
+		$proxy = new WP_HTTP_Proxy();
+
+		if ( $proxy->is_enabled() && $proxy->send_through_proxy( $url ) ) {
+
+			curl_setopt( $handle, CURLOPT_PROXYTYPE, CURLPROXY_HTTP );
+			curl_setopt( $handle, CURLOPT_PROXY, $proxy->host() );
+			curl_setopt( $handle, CURLOPT_PROXYPORT, $proxy->port() );
+
+			if ( $proxy->use_authentication() ) {
+				curl_setopt( $handle, CURLOPT_PROXYAUTH, CURLAUTH_ANY );
+				curl_setopt( $handle, CURLOPT_PROXYUSERPWD, $proxy->authentication() );
+			}
+		}
+
+		$is_local = isset($r['local']) && $r['local'];
+		$ssl_verify = isset($r['sslverify']) && $r['sslverify'];
+		if ( $is_local ) {
+			/** This filter is documented in wp-includes/class-wp-http-streams.php */
+			$ssl_verify = apply_filters( 'https_local_ssl_verify', $ssl_verify );
+		} elseif ( ! $is_local ) {
+			/** This filter is documented in wp-includes/class-wp-http-streams.php */
+			$ssl_verify = apply_filters( 'https_ssl_verify', $ssl_verify );
+		}
+
+		/*
+		 * CURLOPT_TIMEOUT and CURLOPT_CONNECTTIMEOUT expect integers. Have to use ceil since.
+		 * a value of 0 will allow an unlimited timeout.
+		 */
+		$timeout = (int) ceil( $r['timeout'] );
+		curl_setopt( $handle, CURLOPT_CONNECTTIMEOUT, $timeout );
+		curl_setopt( $handle, CURLOPT_TIMEOUT, $timeout );
+
+		curl_setopt( $handle, CURLOPT_URL, $url);
+		curl_setopt( $handle, CURLOPT_RETURNTRANSFER, true );
+		curl_setopt( $handle, CURLOPT_SSL_VERIFYHOST, ( $ssl_verify === true ) ? 2 : false );
+		curl_setopt( $handle, CURLOPT_SSL_VERIFYPEER, $ssl_verify );
+
+		if ( $ssl_verify ) {
+			curl_setopt( $handle, CURLOPT_CAINFO, $r['sslcertificates'] );
+		}
+
+		curl_setopt( $handle, CURLOPT_USERAGENT, $r['user-agent'] );
+
+		/*
+		 * The option doesn't work with safe mode or when open_basedir is set, and there's
+		 * a bug #17490 with redirected POST requests, so handle redirections outside Curl.
+		 */
+		curl_setopt( $handle, CURLOPT_FOLLOWLOCATION, false );
+		if ( defined( 'CURLOPT_PROTOCOLS' ) ) // PHP 5.2.10 / cURL 7.19.4
+			curl_setopt( $handle, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS );
+
+		switch ( $r['method'] ) {
+			case 'HEAD':
+				curl_setopt( $handle, CURLOPT_NOBODY, true );
+				break;
+			case 'POST':
+				curl_setopt( $handle, CURLOPT_POST, true );
+				curl_setopt( $handle, CURLOPT_POSTFIELDS, $r['body'] );
+				break;
+			case 'PUT':
+				curl_setopt( $handle, CURLOPT_CUSTOMREQUEST, 'PUT' );
+				curl_setopt( $handle, CURLOPT_POSTFIELDS, $r['body'] );
+				break;
+			default:
+				curl_setopt( $handle, CURLOPT_CUSTOMREQUEST, $r['method'] );
+				if ( ! is_null( $r['body'] ) )
+					curl_setopt( $handle, CURLOPT_POSTFIELDS, $r['body'] );
+				break;
+		}
+
+		if ( true === $r['blocking'] ) {
+			curl_setopt( $handle, CURLOPT_HEADERFUNCTION, array( $this, 'stream_headers' ) );
+			curl_setopt( $handle, CURLOPT_WRITEFUNCTION, array( $this, 'stream_body' ) );
+		}
+
+		curl_setopt( $handle, CURLOPT_HEADER, false );
+
+		if ( isset( $r['limit_response_size'] ) )
+			$this->max_body_length = intval( $r['limit_response_size'] );
+		else
+			$this->max_body_length = false;
+
+		// If streaming to a file open a file handle, and setup our curl streaming handler.
+		if ( $r['stream'] ) {
+			if ( ! WP_DEBUG )
+				$this->stream_handle = @fopen( $r['filename'], 'w+' );
+			else
+				$this->stream_handle = fopen( $r['filename'], 'w+' );
+			if ( ! $this->stream_handle )
+				return new WP_Error( 'http_request_failed', sprintf( __( 'Could not open handle for fopen() to %s' ), $r['filename'] ) );
+		} else {
+			$this->stream_handle = false;
+		}
+
+		if ( !empty( $r['headers'] ) ) {
+			// cURL expects full header strings in each element.
+			$headers = array();
+			foreach ( $r['headers'] as $name => $value ) {
+				$headers[] = "{$name}: $value";
+			}
+			curl_setopt( $handle, CURLOPT_HTTPHEADER, $headers );
+		}
+
+		if ( $r['httpversion'] == '1.0' )
+			curl_setopt( $handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0 );
+		else
+			curl_setopt( $handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1 );
+
+		/**
+		 * Fires before the cURL request is executed.
+		 *
+		 * Cookies are not currently handled by the HTTP API. This action allows
+		 * plugins to handle cookies themselves.
+		 *
+		 * @since 2.8.0
+		 *
+		 * @param resource &$handle The cURL handle returned by curl_init().
+		 * @param array    $r       The HTTP request arguments.
+		 * @param string   $url     The request URL.
+		 */
+		do_action_ref_array( 'http_api_curl', array( &$handle, $r, $url ) );
+
+		// We don't need to return the body, so don't. Just execute request and return.
+		if ( ! $r['blocking'] ) {
+			curl_exec( $handle );
+
+			if ( $curl_error = curl_error( $handle ) ) {
+				curl_close( $handle );
+				return new WP_Error( 'http_request_failed', $curl_error );
+			}
+			if ( in_array( curl_getinfo( $handle, CURLINFO_HTTP_CODE ), array( 301, 302 ) ) ) {
+				curl_close( $handle );
+				return new WP_Error( 'http_request_failed', __( 'Too many redirects.' ) );
+			}
+
+			curl_close( $handle );
+			return array( 'headers' => array(), 'body' => '', 'response' => array('code' => false, 'message' => false), 'cookies' => array() );
+		}
+
+		curl_exec( $handle );
+		$theHeaders = WP_Http::processHeaders( $this->headers, $url );
+		$theBody = $this->body;
+		$bytes_written_total = $this->bytes_written_total;
+
+		$this->headers = '';
+		$this->body = '';
+		$this->bytes_written_total = 0;
+
+		$curl_error = curl_errno( $handle );
+
+		// If an error occurred, or, no response.
+		if ( $curl_error || ( 0 == strlen( $theBody ) && empty( $theHeaders['headers'] ) ) ) {
+			if ( CURLE_WRITE_ERROR /* 23 */ == $curl_error ) {
+				if ( ! $this->max_body_length || $this->max_body_length != $bytes_written_total ) {
+					if ( $r['stream'] ) {
+						curl_close( $handle );
+						fclose( $this->stream_handle );
+						return new WP_Error( 'http_request_failed', __( 'Failed to write request to temporary file.' ) );
+					} else {
+						curl_close( $handle );
+						return new WP_Error( 'http_request_failed', curl_error( $handle ) );
+					}
+				}
+			} else {
+				if ( $curl_error = curl_error( $handle ) ) {
+					curl_close( $handle );
+					return new WP_Error( 'http_request_failed', $curl_error );
+				}
+			}
+			if ( in_array( curl_getinfo( $handle, CURLINFO_HTTP_CODE ), array( 301, 302 ) ) ) {
+				curl_close( $handle );
+				return new WP_Error( 'http_request_failed', __( 'Too many redirects.' ) );
+			}
+		}
+
+		curl_close( $handle );
+
+		if ( $r['stream'] )
+			fclose( $this->stream_handle );
+
+		$response = array(
+			'headers' => $theHeaders['headers'],
+			'body' => null,
+			'response' => $theHeaders['response'],
+			'cookies' => $theHeaders['cookies'],
+			'filename' => $r['filename']
+		);
+
+		// Handle redirects.
+		if ( false !== ( $redirect_response = WP_HTTP::handle_redirects( $url, $r, $response ) ) )
+			return $redirect_response;
+
+		if ( true === $r['decompress'] && true === WP_Http_Encoding::should_decode($theHeaders['headers']) )
+			$theBody = WP_Http_Encoding::decompress( $theBody );
+
+		$response['body'] = $theBody;
+
+		return $response;
+	}
+
+	/**
+	 * Grab the headers of the cURL request
+	 *
+	 * Each header is sent individually to this callback, so we append to the $header property for temporary storage
+	 *
+	 * @since 3.2.0
+	 * @access private
+	 * @return int
+	 */
+	private function stream_headers( $handle, $headers ) {
+		$this->headers .= $headers;
+		return strlen( $headers );
+	}
+
+	/**
+	 * Grab the body of the cURL request
+	 *
+	 * The contents of the document are passed in chunks, so we append to the $body property for temporary storage.
+	 * Returning a length shorter than the length of $data passed in will cause cURL to abort the request with CURLE_WRITE_ERROR
+	 *
+	 * @since 3.6.0
+	 * @access private
+	 * @return int
+	 */
+	private function stream_body( $handle, $data ) {
+		$data_length = strlen( $data );
+
+		if ( $this->max_body_length && ( $this->bytes_written_total + $data_length ) > $this->max_body_length ) {
+			$data_length = ( $this->max_body_length - $this->bytes_written_total );
+			$data = substr( $data, 0, $data_length );
+		}
+
+		if ( $this->stream_handle ) {
+			$bytes_written = fwrite( $this->stream_handle, $data );
+		} else {
+			$this->body .= $data;
+			$bytes_written = $data_length;
+		}
+
+		$this->bytes_written_total += $bytes_written;
+
+		// Upon event of this function returning less than strlen( $data ) curl will error with CURLE_WRITE_ERROR.
+		return $bytes_written;
+	}
+
+	/**
+	 * Whether this class can be used for retrieving an URL.
+	 *
+	 * @static
+	 * @since 2.7.0
+	 *
+	 * @return bool False means this class can not be used, true means it can.
+	 */
+	public static function test( $args = array() ) {
+		if ( ! function_exists( 'curl_init' ) || ! function_exists( 'curl_exec' ) )
+			return false;
+
+		$is_ssl = isset( $args['ssl'] ) && $args['ssl'];
+
+		if ( $is_ssl ) {
+			$curl_version = curl_version();
+			// Check whether this cURL version support SSL requests.
+			if ( ! (CURL_VERSION_SSL & $curl_version['features']) )
+				return false;
+		}
+
+		/**
+		 * Filter whether cURL can be used as a transport for retrieving a URL.
+		 *
+		 * @since 2.7.0
+		 *
+		 * @param bool  $use_class Whether the class can be used. Default true.
+		 * @param array $args      An array of request arguments.
+		 */
+		return apply_filters( 'use_curl_transport', true, $args );
+	}
+}

--- a/wp-web-push/class-wp-http-curl-multi.php
+++ b/wp-web-push/class-wp-http-curl-multi.php
@@ -68,14 +68,6 @@ class WP_Http_Curl_Multi {
 
 		$r = wp_parse_args( $args, $defaults );
 
-		if ( isset( $r['headers']['User-Agent'] ) ) {
-			$r['user-agent'] = $r['headers']['User-Agent'];
-			unset( $r['headers']['User-Agent'] );
-		} elseif ( isset( $r['headers']['user-agent'] ) ) {
-			$r['user-agent'] = $r['headers']['user-agent'];
-			unset( $r['headers']['user-agent'] );
-		}
-
 		// Construct Cookie: header if any cookies are set.
 		WP_Http::buildCookieHeader( $r );
 
@@ -122,8 +114,6 @@ class WP_Http_Curl_Multi {
 		if ( $ssl_verify ) {
 			curl_setopt( $handle, CURLOPT_CAINFO, $r['sslcertificates'] );
 		}
-
-		curl_setopt( $handle, CURLOPT_USERAGENT, $r['user-agent'] );
 
 		/*
 		 * The option doesn't work with safe mode or when open_basedir is set, and there's

--- a/wp-web-push/web-push.php
+++ b/wp-web-push/web-push.php
@@ -8,7 +8,7 @@ define('GCM_REQUEST_URL_LEN', strlen(GCM_REQUEST_URL) + 1);
 class WebPush {
   private $useMulti;
   private $httpCurlMulti;
-  private $requests = array();
+  public $requests = array();
 
   function __construct() {
     $this->useMulti = WP_Http_Curl_Multi::test();

--- a/wp-web-push/web-push.php
+++ b/wp-web-push/web-push.php
@@ -10,8 +10,8 @@ class WebPush {
   private $httpCurlMulti;
   public $requests = array();
 
-  function __construct() {
-    $this->useMulti = WP_Http_Curl_Multi::test();
+  function __construct($forceWP = false) {
+    $this->useMulti = !$forceWP && WP_Http_Curl_Multi::test();
     if ($this->useMulti) {
       $this->httpCurlMulti = new WP_Http_Curl_Multi();
     }

--- a/wp-web-push/web-push.php
+++ b/wp-web-push/web-push.php
@@ -9,6 +9,7 @@ class WebPush {
   private $useMulti;
   private $httpCurlMulti;
   public $requests = array();
+  private $gcmKey;
 
   function __construct($forceWP = false) {
     $this->useMulti = !$forceWP && WP_Http_Curl_Multi::test();
@@ -17,7 +18,11 @@ class WebPush {
     }
   }
 
-  function addRecipient($endpoint, $gcmKey, $callback) {
+  function setGCMKey($gcmKey) {
+    $this->gcmKey = $gcmKey;
+  }
+
+  function addRecipient($endpoint, $callback) {
     $headers = array();
     $requestURL = $endpoint;
     $body = '';
@@ -26,7 +31,7 @@ class WebPush {
       $subscriptionId = substr($endpoint, GCM_REQUEST_URL_LEN);
       $body = '{"registration_ids":["' . $subscriptionId . '"]}';
 
-      $headers['Authorization'] = 'key=' . $gcmKey;
+      $headers['Authorization'] = 'key=' . $this->gcmKey;
       $headers['Content-Type'] = 'application/json';
       $headers['Content-Length'] = strlen($body);
       $requestURL = GCM_REQUEST_URL;

--- a/wp-web-push/web-push.php
+++ b/wp-web-push/web-push.php
@@ -19,7 +19,6 @@ class WebPush {
 
   function addRecipient($endpoint, $isGCM, $gcmKey, $callback) {
     $headers = array();
-    $expectedResponseCode = 201;
     $requestURL = $endpoint;
     $body = '';
 
@@ -31,7 +30,6 @@ class WebPush {
       $headers['Content-Type'] = 'application/json';
       $headers['Content-Length'] = strlen($body);
       $requestURL = GCM_REQUEST_URL;
-      $expectedResponseCode = 200;
     } else {
       // Ask the push service to store the message for 4 weeks.
       $headers['TTL'] = 2419200;
@@ -42,7 +40,6 @@ class WebPush {
       'headers' => $headers,
       'body' => $body,
       'callback' => $callback,
-      'expected' => $expectedResponseCode,
     );
   }
 
@@ -96,7 +93,7 @@ class WebPush {
                // If there's an error during the request, return true
                // so the caller doesn't think the request failed.
                is_wp_error($result) ||
-               $result['response']['code'] === $request['expected'];
+               in_array($result['response']['code'], array(200, 201));
 
         call_user_func($request['callback'], $ret);
       }

--- a/wp-web-push/web-push.php
+++ b/wp-web-push/web-push.php
@@ -1,45 +1,85 @@
 <?php
 
+require_once(plugin_dir_path(__FILE__) . 'class-wp-http-curl-multi.php' );
+
 define('GCM_REQUEST_URL', 'https://android.googleapis.com/gcm/send');
 define('GCM_REQUEST_URL_LEN', strlen(GCM_REQUEST_URL) + 1);
 
-function sendNotification($endpoint, $isGCM, $gcmKey, $sync) {
-  $headers = array();
-  $expectedResponseCode = 201;
-  $requestURL = $endpoint;
-  $body = '';
+class WebPush {
+  private $useMulti;
+  private $httpCurlMulti;
+  private $requests = array();
 
-  if ($isGCM) {
-    $subscriptionId = substr($endpoint, GCM_REQUEST_URL_LEN);
-    $body = '{"registration_ids":["' . $subscriptionId . '"]}';
-
-    $headers['Authorization'] = 'key=' . $gcmKey;
-    $headers['Content-Type'] = 'application/json';
-    $headers['Content-Length'] = strlen($body);
-    $requestURL = GCM_REQUEST_URL;
-    $expectedResponseCode = 200;
-  } else {
-    // Ask the push service to store the message for 4 weeks.
-    $headers['TTL'] = 2419200;
+  function __construct() {
+    $this->useMulti = WP_Http_Curl_Multi::test();
+    if ($this->useMulti) {
+      $this->httpCurlMulti = new WP_Http_Curl_Multi();
+    }
   }
 
-  $result = wp_remote_post($requestURL, array(
-    'blocking' => $sync ? true : false,
-    'headers' => $headers,
-    'body' => $body,
-  ));
+  function addRecipient($endpoint, $isGCM, $gcmKey) {
+    $headers = array();
+    $expectedResponseCode = 201;
+    $requestURL = $endpoint;
+    $body = '';
 
-  if (!$sync) {
-    return true;
+    if ($isGCM) {
+      $subscriptionId = substr($endpoint, GCM_REQUEST_URL_LEN);
+      $body = '{"registration_ids":["' . $subscriptionId . '"]}';
+
+      $headers['Authorization'] = 'key=' . $gcmKey;
+      $headers['Content-Type'] = 'application/json';
+      $headers['Content-Length'] = strlen($body);
+      $requestURL = GCM_REQUEST_URL;
+      $expectedResponseCode = 200;
+    } else {
+      // Ask the push service to store the message for 4 weeks.
+      $headers['TTL'] = 2419200;
+    }
+
+    $this->requests[] = array(
+      'url' => $requestURL,
+      'args' => array(
+        'headers' => $headers,
+        'body' => $body,
+        'method' => 'POST',
+      )
+    );
   }
 
-  if (is_wp_error($result)) {
-    // If there's an error during the request, return true
-    // so the caller doesn't think the request failed.
-    return true;
-  }
+  function sendNotifications() {
+    if ($this->useMulti) {
+      $handles = array();
+      foreach ($this->requests as $request) {
+        $handles[] = $this->httpCurlMulti->createHandle($request['url'], $request['args']);
+      }
 
-  return $result['response']['code'] === $expectedResponseCode;
+      $mh = curl_multi_init();
+      foreach ($handles as $handle) {
+        curl_multi_add_handle($mh, $handle);
+      }
+
+      $still_running = true;
+      do {
+        curl_multi_exec($mh, $still_running);
+        curl_multi_select($mh);
+      } while ($still_running);
+
+      foreach ($handles as $handle) {
+        curl_multi_remove_handle($mh, $handle);
+      }
+
+      curl_multi_close($mh);
+    } else {
+      foreach ($this->requests as $request) {
+        wp_remote_post($requestURL, array(
+          'blocking' => false,
+          'headers' => $headers,
+          'body' => $body,
+        ));
+      }
+    }
+  }
 }
 
 ?>

--- a/wp-web-push/web-push.php
+++ b/wp-web-push/web-push.php
@@ -17,12 +17,12 @@ class WebPush {
     }
   }
 
-  function addRecipient($endpoint, $isGCM, $gcmKey, $callback) {
+  function addRecipient($endpoint, $gcmKey, $callback) {
     $headers = array();
     $requestURL = $endpoint;
     $body = '';
 
-    if ($isGCM) {
+    if (strpos($endpoint, GCM_REQUEST_URL) === 0) {
       $subscriptionId = substr($endpoint, GCM_REQUEST_URL_LEN);
       $body = '{"registration_ids":["' . $subscriptionId . '"]}';
 

--- a/wp-web-push/wp-web-push-main.php
+++ b/wp-web-push/wp-web-push-main.php
@@ -226,20 +226,15 @@ class WebPush_Main {
         continue;
       }
 
-      // TODO: Clean approximately ten random subscriptions, to avoid performance problems
-      // with sending too many synchronous requests.
-      //$sync = mt_rand(1, $subscription_num) <= 10;
-
-      /*if (!sendNotification($subscription->endpoint, $isGCM, $gcmKey, $sync)) {
-        // If there's an error while sending the push notification,
-        // the subscription is no longer valid, hence we remove it.
-        WebPush_DB::remove_subscription($subscription->endpoint);
-      } else {
-        $notification_count++;
-      }*/
-
-      $webPush->addRecipient($subscription->endpoint, $isGCM, $gcmKey);
-      $notification_count++;
+      $webPush->addRecipient($subscription->endpoint, $isGCM, $gcmKey, function($success) use ($subscription, &$notification_count) {
+        if (!$success) {
+          // If there's an error while sending the push notification,
+          // the subscription is no longer valid, hence we remove it.
+          WebPush_DB::remove_subscription($subscription->endpoint);
+        } else {
+          $notification_count++;
+        }
+      });
     }
 
     $webPush->sendNotifications();

--- a/wp-web-push/wp-web-push-main.php
+++ b/wp-web-push/wp-web-push-main.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once(plugin_dir_path(__FILE__) . 'web-push.php' );
 require_once(plugin_dir_path(__FILE__) . 'wp-web-push-db.php');
 
 class WebPush_Main {
@@ -187,6 +186,8 @@ class WebPush_Main {
     if (!isset($_REQUEST['webpush_send_notification'])) {
       return;
     }
+
+    require_once(plugin_dir_path(__FILE__) . 'web-push.php' );
 
     $title_option = get_option('webpush_title');
 

--- a/wp-web-push/wp-web-push-main.php
+++ b/wp-web-push/wp-web-push-main.php
@@ -189,6 +189,8 @@ class WebPush_Main {
 
     require_once(plugin_dir_path(__FILE__) . 'web-push.php' );
 
+    $webPush = new WebPush();
+
     $title_option = get_option('webpush_title');
 
     $icon = get_option('webpush_icon');
@@ -224,18 +226,23 @@ class WebPush_Main {
         continue;
       }
 
-      // Clean approximately ten random subscriptions, to avoid performance problems
+      // TODO: Clean approximately ten random subscriptions, to avoid performance problems
       // with sending too many synchronous requests.
-      $sync = mt_rand(1, $subscription_num) <= 10;
+      //$sync = mt_rand(1, $subscription_num) <= 10;
 
-      if (!sendNotification($subscription->endpoint, $isGCM, $gcmKey, $sync)) {
+      /*if (!sendNotification($subscription->endpoint, $isGCM, $gcmKey, $sync)) {
         // If there's an error while sending the push notification,
         // the subscription is no longer valid, hence we remove it.
         WebPush_DB::remove_subscription($subscription->endpoint);
       } else {
         $notification_count++;
-      }
+      }*/
+
+      $webPush->addRecipient($subscription->endpoint, $isGCM, $gcmKey);
+      $notification_count++;
     }
+
+    $webPush->sendNotifications();
 
     update_post_meta($post->ID, '_notifications_clicked', 0);
     update_post_meta($post->ID, '_notifications_sent', $notification_count);

--- a/wp-web-push/wp-web-push-main.php
+++ b/wp-web-push/wp-web-push-main.php
@@ -210,6 +210,7 @@ class WebPush_Main {
     ));
 
     $gcmKey = get_option('webpush_gcm_key');
+    $webPush->setGCMKey($gcmKey);
 
     $notification_count = 0;
 
@@ -226,7 +227,7 @@ class WebPush_Main {
         continue;
       }
 
-      $webPush->addRecipient($subscription->endpoint, $gcmKey, function($success) use ($subscription, &$notification_count) {
+      $webPush->addRecipient($subscription->endpoint, function($success) use ($subscription, &$notification_count) {
         if (!$success) {
           // If there's an error while sending the push notification,
           // the subscription is no longer valid, hence we remove it.

--- a/wp-web-push/wp-web-push-main.php
+++ b/wp-web-push/wp-web-push-main.php
@@ -226,7 +226,7 @@ class WebPush_Main {
         continue;
       }
 
-      $webPush->addRecipient($subscription->endpoint, $isGCM, $gcmKey, function($success) use ($subscription, &$notification_count) {
+      $webPush->addRecipient($subscription->endpoint, $gcmKey, function($success) use ($subscription, &$notification_count) {
         if (!$success) {
           // If there's an error while sending the push notification,
           // the subscription is no longer valid, hence we remove it.


### PR DESCRIPTION
Fixes #265.

Need to fix the tests that send a notification (we used to override the HTTP request with a WordPress filter, but we can't do that anymore with the custom implementation).
We should test the WebPush class both with curl_multi_\* and without.
