### PR TITLE
Fix transition post status tests on WP 3.7, 3.8, 3.9

### DIFF
--- a/tests/test-transition-post-status.php
+++ b/tests/test-transition-post-status.php
@@ -6,7 +6,9 @@ class TransitionPostStatusTest extends WP_UnitTestCase {
   function setUp() {
     parent::setUp();
 
-    WebPush_DB::add_subscription('http://localhost:55555/201', 'aKey');
+    if (!WebPush_DB::is_subscription('http://localhost:55555/201')) {
+      WebPush_DB::add_subscription('http://localhost:55555/201', 'aKey');
+    }
 
     $_REQUEST['webpush_meta_box_nonce'] = wp_create_nonce('webpush_send_notification');
     $_REQUEST['webpush_send_notification'] = 1;

--- a/tests/test-transition-post-status.php
+++ b/tests/test-transition-post-status.php
@@ -6,12 +6,12 @@ class TransitionPostStatusTest extends WP_UnitTestCase {
   function setUp() {
     parent::setUp();
 
-    if (!WebPush_DB::is_subscription('http://localhost:55555/201')) {
-      WebPush_DB::add_subscription('http://localhost:55555/201', 'aKey');
-    }
+    WebPush_DB::add_subscription('http://localhost:55555/201', 'aKey');
 
     $_REQUEST['webpush_meta_box_nonce'] = wp_create_nonce('webpush_send_notification');
     $_REQUEST['webpush_send_notification'] = 1;
+
+    remove_all_actions('transition_post_status');
   }
 
   function test_empty_post() {


### PR DESCRIPTION
Fixes #292.
