### PR TITLE
Don't show multiple notifications when the browser is opened

### DIFF
--- a/wp-web-push/lib/js/sw.php
+++ b/wp-web-push/lib/js/sw.php
@@ -43,13 +43,17 @@
     );
   });
 
+  var lastNotificationTime;
+
   self.addEventListener('push', function(event) {
     event.waitUntil(
-      localforage.getItem('lastNotificationTime')
-      .then(function(lastNotificationTime) {
+      Promise.resolve()
+      .then(function() {
         if (lastNotificationTime && (Date.now() < lastNotificationTime + 30000)) {
           return;
         }
+
+        lastNotificationTime = Date.now();
 
         return fetch('<?php echo admin_url('admin-ajax.php'); ?>?action=webpush_get_payload')
         .then(function(response) {
@@ -62,9 +66,6 @@
             data: data,
             tag: 'wp-web-push',
           });
-        })
-        .then(function() {
-          return localforage.setItem('lastNotificationTime', Date.now());
         });
       })
     );

--- a/wp-web-push/lib/js/sw.php
+++ b/wp-web-push/lib/js/sw.php
@@ -43,13 +43,13 @@
     );
   });
 
-  var lastNotificationTime;
+  var lastNotificationTime = 0;
 
   self.addEventListener('push', function(event) {
     event.waitUntil(
       Promise.resolve()
       .then(function() {
-        if (lastNotificationTime && (Date.now() < lastNotificationTime + 30000)) {
+        if (Date.now() < lastNotificationTime + 30000) {
           return;
         }
 


### PR DESCRIPTION
This finally fixes https://wordpress.org/support/topic/115-with-high-frequent-site?replies=24.

When many notifications are sent while you have your browser closed, when you open it again you'll get a burst of notifications.
